### PR TITLE
Fix locales and add a tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
 ARG tag="debian:latest"
 FROM ${tag}
 
-# Set locale to fix character encoding
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install a few things that might be helpful
 RUN apt-get update && apt-get install -y \
+  locales \
   devscripts \
   debhelper \
   equivs \
   less \
   vim 
+
+# Set locale to fix character encoding
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 COPY run_and_copy.sh /
 WORKDIR /make

--- a/dockermake
+++ b/dockermake
@@ -15,6 +15,9 @@ case "$tag" in
     "trusty")
         tag="ubuntu:trusty"
         ;;
+    "utopic")
+        tag="ubuntu:utopic"
+        ;;
     "xenial")
         tag="ubuntu:xenial"
         ;;
@@ -23,6 +26,6 @@ esac
 docker build \
     --build-arg tag=$tag \
     -t \
-    precise-make \
+    dm-$tag \
     .
-docker run --rm -it -v "${PWD}/output:/out" precise-make $@
+docker run --rm -it -v "${PWD}/output:/out" dm-$tag $@


### PR DESCRIPTION
When using with Utopic I noticed:

- not every tag comes with locales for locale fix if you don't install it
- utopic tag didn't have an alias
- built image always called itself precise